### PR TITLE
fix: publish workflow

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -17,8 +17,6 @@ jobs:
         uses: ./.github/actions/init-npm
         with:
           node-version: 20.x
-      - name: Copy resources
-        run: npm run copy
       - uses: JS-DevTools/npm-publish@v3
         with:
           token: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
| Question                | Answer                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix         | ✔                                                                     |

Further information: 
remove: `npm run copy` - no need for assets copy in this package.
